### PR TITLE
add_plugins_page requires cap not role

### DIFF
--- a/indieweb.php
+++ b/indieweb.php
@@ -50,7 +50,7 @@ class IndieWebPlugin {
    * add menu item
    */
   public static function add_menu_item() {
-    add_plugins_page('IndieWeb', 'IndieWeb', 'administrator', 'indieweb', array('IndieWebPlugin', 'settings'));
+    add_plugins_page('IndieWeb', 'IndieWeb', 'manage_options', 'indieweb', array('IndieWebPlugin', 'settings'));
   }
 
   /**


### PR DESCRIPTION
This PR should solve #9 because `administrator` is not a valid capability.