### PR TITLE
Make remaining text translatable

### DIFF
--- a/getting_started.php
+++ b/getting_started.php
@@ -1,50 +1,60 @@
-     <h1>IndieWebify your WordPress-Blog</h1>
+<h1><?php _e( 'IndieWebify your WordPress-Blog', 'indieweb' ); ?></h1>
 
-    <h2>Getting Started</h2>
+<h2><?php _e( 'Getting Started', 'indieweb' ); ?></h2>
 
-    <p>The Indieweb Plugin can help you get set up to be a more active member of the indieweb. Required plugins make receiving indieweb comments and mentions work, recommended plugins further improve the experience.</p>
-    <p>Once you have these activated, you can setup <a href="https://www.brid.gy" target="_blank">Bridgy</a> to connect your blog to responses from sites such as Facebook and Twitter too, allowing for a seamless experience.</p>
-    <h2>Plugins</h2>
+<p><?php _e( 'The Indieweb Plugin can help you get set up to be a more active member of the indieweb. Required plugins make receiving indieweb comments and mentions work, recommended plugins further improve the experience.', 'indieweb' ); ?></p>
 
-    <p>For more information on these plugins, visit the <a href="http://indiewebcamp.com/wordpress" target="_blank">WordPress page</a> on the Indiewebcamp wiki.
-or click the individual plugin links below.</p>
+<p><?php _e( 'Once you have these activated, you can setup <a href="https://www.brid.gy" target="_blank">Bridgy</a> to connect your blog to responses from sites such as Facebook and Twitter too, allowing for a seamless experience.', 'indieweb' ); ?></p>
 
+<h2><?php _e( 'Plugins', 'indieweb' ); ?></h2>
 
-    <ul><li><h3>Send and receive responses with your site </h3>
-	<p>Send and receive comments, likes, reposts, and other kinds of post responses using your own site!</p>
-	<ol>
-      	<li><strong>Webmention</strong> <em>(Required)</em> - allows you to send and receive by adding webmention support to WordPress. Mentions show up as comments on your site. </li>
-      	<li><strong>Semantic Linkbacks</strong> <em>(Required)</em> - makes indieweb comments and mentions look better on your site. </li>
-      	<li><strong>Webmention for (Threaded) Comments</strong> - Adds support for threaded comments for webmentions.</li>
-      	<li><strong>Webactions</strong> - Adds webaction markups to WordPress elements</li>
-      	<li><strong>Post Kinds</strong> - Allows you to reply/like/RSVP etc to another site from your own, by adding support for kinds of posts to WordPress as a custom taxonomy. </li>
-	</ol></li>
-      <li><h3>Syndicate your content to other sites</h3>
-	<p>Choose one of these different ways to display links for POSSE/syndicated versions of a post. They cannot both be used. Linking to the syndicated version of a post allows for bridgy to be able to discover the post as well as for end users to comment on those sites as a way of replying.</p>
-         <ol>
-           <li><strong>Syndication Links</strong> - Adds fields to a post to allow manual entry of syndication links</li>
-           <li><strong>WordPress Syndication</strong> - automatically adds link to a post from a supported syndication plugin. Fully supports Social, partial support for SNAP, and support for Bridgy Publish</li>
-        </ol></li>
-	<li><h3>Other</h3>
-      <ol><li><strong>Indieweb Press-This</strong> - Adds Indieweb markup to the WordPressPress-This bookmarkets to allow you to respond on your site with one-click</li>
-      <li><strong>Hum URL Shortener</strong> - A personal URL shortener</li>
-      <li><strong>Indieauth</strong> - The plugin lets you login to the WordPress backend via IndieAuth. It uses the URL from the profile page to identify the blog user.</li>
-    </ol></li>
-	</ul>
+<p><?php _e( 'For more information on these plugins, visit the <a href="http://indiewebcamp.com/wordpress" target="_blank">WordPress page</a> on the Indiewebcamp wiki or click the individual plugin links below.', 'indieweb' ); ?></p>
 
-    <p><a href="<?php echo admin_url('options-general.php?page=indieweb-installer'); ?>" class="button button-primary">Install Plugins</a></p>
-  
-    <h2>Themes</h2>
+<ul>
+	<li>
+		<h3><?php _e( 'Send and receive responses with your site', 'indieweb' ); ?></h3>
+		<p><?php _e( 'Send and receive comments, likes, reposts, and other kinds of post responses using your own site!', 'indieweb' ); ?></p>
+		<ol>
+			<li><?php _e( '<strong>Webmention</strong> <em>(Required)</em> - allows you to send and receive by adding webmention support to WordPress. Mentions show up as comments on your site.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>Semantic Linkbacks</strong> <em>(Required)</em> - makes indieweb comments and mentions look better on your site.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>Webmention for (Threaded) Comments</strong> - Adds support for threaded comments for webmentions.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>Webactions</strong> - Adds webaction markups to WordPress elements.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>Post Kinds</strong> - Allows you to reply/like/RSVP etc to another site from your own, by adding support for kinds of posts to WordPress as a custom taxonomy.', 'indieweb' ); ?></li>
+		</ol>
+	</li>
 
-<p>Some WordPress themes are compatible with microformats. The Indieweb uses microformats2, the latest version, to mark up sites so that they can be interpreted by other sites when retrieved. Most parsers will fall back onto the older format if available.</p>
+	<li>
+		<h3><?php _e( 'Syndicate your content to other sites', 'indieweb' ); ?></h3>
+		<p><?php _e( 'Choose one of these different ways to display links for POSSE/syndicated versions of a post. They cannot both be used. Linking to the syndicated version of a post allows for bridgy to be able to discover the post as well as for end users to comment on those sites as a way of replying.', 'indieweb' ); ?></p>
+		<ol>
+			<li><?php _e( '<strong>Syndication Links</strong> - Adds fields to a post to allow manual entry of syndication links.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>WordPress Syndication</strong> - automatically adds link to a post from a supported syndication plugin. Fully supports Social, partial support for SNAP, and support for Bridgy Publish.', 'indieweb' ); ?></li>
+		</ol>
+	</li>
 
-<p.Formatting your site so other sites can consume the information allows for the communications Indieweb sites support. For example, a class of u-like-of added to a link to a site you liked to indicates that relationship.</p>
+	<li>
+		<h3><?php _e( 'Other', 'indieweb' ); ?></h3>
+		<ol>
+			<li><?php _e( '<strong>Indieweb Press-This</strong> - Adds Indieweb markup to the WordPressPress-This bookmarkets to allow you to respond on your site with one-click.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>Hum URL Shortener</strong> - A personal URL shortener.', 'indieweb' ); ?></li>
+			<li><?php _e( '<strong>Indieauth</strong> - The plugin lets you login to the WordPress backend via IndieAuth. It uses the URL from the profile page to identify the blog user.', 'indieweb' ); ?></li>
+		</ol>
+	</li>
+</ul>
 
-<p>There is only one theme in the WordPress repository that is fully microformats2 compliant. That is Sempress.</p>
+<p><a href="<?php echo admin_url('options-general.php?page=indieweb-installer'); ?>" class="button button-primary"><?php _e( 'Install Plugins', 'indieweb' ); ?></a></p>
 
-    <h2>What is the Indieweb?</h2>
+<h2><?php _e( 'Themes', 'indieweb' ); ?></h2>
 
-    <p><strong>Own your data.</strong> Create and publish content on your own site, and only optionally syndicate to third-party silos.</p>
-    <p>This is the basis of the <strong>Indie Web</strong>. For more, see <a href="http://indiewebcamp.com/principles" target="_blank">principles</a> and <a href="http://indiewebcamp.com/why" target="_blank">why</a>.</p>
+<p><?php _e( 'Some WordPress themes are compatible with microformats. The Indieweb uses microformats2, the latest version, to mark up sites so that they can be interpreted by other sites when retrieved. Most parsers will fall back onto the older format if available.', 'indieweb' ); ?></p>
 
-    <p>For even more information, please visit the <a href="http://indiewebcamp.com/" target="_blank"><em>IndieWebCamp</em> wiki</a>.</p>
+<p><?php _e( 'Formatting your site so other sites can consume the information allows for the communications Indieweb sites support. For example, a class of u-like-of added to a link to a site you liked to indicates that relationship.', 'indieweb' ); ?></p>
+
+<p><?php _e( 'There is only one theme in the WordPress repository that is fully microformats2 compliant. That is Sempress.', 'indieweb' ); ?></p>
+
+<h2><?php _e( 'What is the Indieweb?', 'indieweb' ); ?></h2>
+
+<p><?php _e( '<strong>Own your data.</strong> Create and publish content on your own site, and only optionally syndicate to third-party silos.', 'indieweb' ); ?></p>
+<p><?php _e( 'This is the basis of the <strong>Indie Web</strong>. For more, see <a href="http://indiewebcamp.com/principles" target="_blank">principles</a> and <a href="http://indiewebcamp.com/why" target="_blank">why</a>.', 'indieweb' ); ?></p>
+
+<p><?php _e( 'For even more information, please visit the <a href="http://indiewebcamp.com/" target="_blank"><em>IndieWebCamp</em> wiki</a>.', 'indieweb' ); ?></p>

--- a/indieweb.php
+++ b/indieweb.php
@@ -62,7 +62,7 @@ class IndieWebPlugin {
    * add menu item
    */
   public static function add_menu_item() {
-    add_plugins_page('IndieWeb', 'IndieWeb', 'manage_options', 'indieweb', array('IndieWebPlugin', 'settings'));
+    add_plugins_page(__('IndieWeb', 'indieweb'), 'IndieWeb', 'manage_options', 'indieweb', array('IndieWebPlugin', 'settings'));
   }
 
   /**
@@ -92,28 +92,28 @@ class IndieWebPlugin {
 
       // require the WebMention plugin
       array(
-        'name'               => 'WebMention',
+        'name'               => __( 'WebMention', 'indieweb' ),
         'slug'               => 'webmention',
         'required'           => true,
       ),
 
       // require the Semantic Linkbacks plugin
       array(
-        'name'               => 'Semantic Linkbacks',
+        'name'               => __( 'Semantic Linkbacks', 'indieweb' ),
         'slug'               => 'semantic-linkbacks',
         'required'           => true, // If false, the plugin is only 'recommended' instead of required.
       ),
 
       // recommend the Hum URL shortener
       array(
-        'name'      => 'Hum (URL shortener)',
+        'name'      => __( 'Hum (URL shortener)', 'indieweb' ),
         'slug'      => 'hum',
         'required'  => false,
       ),
 
       // recommend the WebActions plugin
       array(
-        'name'          => 'WebActions',
+        'name'          => __( 'WebActions', 'indieweb' ),
         'slug'          => 'wordpress-webactions-master',
         'source'        => 'https://github.com/pfefferle/wordpress-webactions/archive/master.zip',
         'required'      => false,
@@ -122,7 +122,7 @@ class IndieWebPlugin {
 
       // recommend the IndieWeb Press-This plugin
       array(
-        'name'          => 'IndieWeb Press-This',
+        'name'          => __( 'IndieWeb Press-This', 'indieweb' ),
         'slug'          => 'wordpress-indieweb-press-this-master',
         'source'        => 'https://github.com/pfefferle/wordpress-indieweb-press-this/archive/master.zip',
         'required'      => false,
@@ -131,7 +131,7 @@ class IndieWebPlugin {
 
       // recommend the "WebMention for Comments" plugin
       array(
-        'name'          => 'WebMention support for (threaded) comments',
+        'name'          => __( 'WebMention support for (threaded) comments', 'indieweb' ),
         'slug'          => 'wordpress-webmention-for-comments-master',
         'source'        => 'https://github.com/pfefferle/wordpress-webmention-for-comments/archive/master.zip',
         'required'      => false,
@@ -140,7 +140,7 @@ class IndieWebPlugin {
 
       // recommend the Post Kinds plugin
       array(
-        'name'          => 'Post Kinds',
+        'name'          => __( 'Post Kinds', 'indieweb' ),
         'slug'          => 'indieweb-post-kinds-master',
         'source'        => 'https://github.com/dshanske/indieweb-post-kinds/archive/master.zip',
         'required'      => false,
@@ -149,7 +149,7 @@ class IndieWebPlugin {
 
       // recommend the Syndication Links plugin
       array(
-        'name'          => 'Syndication Links',
+        'name'          => __( 'Syndication Links', 'indieweb' ),
         'slug'          => 'syndication-links-master',
         'source'        => 'https://github.com/dshanske/syndication-links/archive/master.zip',
         'required'      => false,
@@ -158,7 +158,7 @@ class IndieWebPlugin {
 
       // recommend the WordPress Syndication plugin
       array(
-        'name'          => 'WordPress Syndication',
+        'name'          => __( 'WordPress Syndication', 'indieweb' ),
         'slug'          => 'wordpress-syndication-master',
         'source'        => 'https://github.com/jihaisse/wordpress-syndication/archive/master.zip',
         'required'      => false,
@@ -167,7 +167,7 @@ class IndieWebPlugin {
 
       // recommend the Indieauth plugin
       array(
-        'name'          => 'Indieauth',
+        'name'          => __( 'Indieauth', 'indieweb' ),
         'slug'          => 'indieauth',
         'required'      => false,
       ),
@@ -190,7 +190,7 @@ class IndieWebPlugin {
       'dismissable'  => true,                    // If false, a user cannot dismiss the nag message.
       'dismiss_msg'  => '',                      // If 'dismissable' is false, this message will be output at top of nag.
       'is_automatic' => false,                   // Automatically activate plugins after installation or not.
-      'message'      => 'For descriptions of the plugins and more information, visit <a href="plugins.php?page=indieweb">Getting Started</a>', // Message to output right before the plugins table.
+      'message'      => __('For descriptions of the plugins and more information, visit <a href="plugins.php?page=indieweb">Getting Started</a>', 'indieweb'), // Message to output right before the plugins table.
       'strings'      => array(
         'page_title'                      => __('Install Indieweb Plugins', 'indieweb'),
         'menu_title'                      => __('IndieWeb Plugin Installer', 'indieweb'),

--- a/languages/wordpress-indieweb.pot
+++ b/languages/wordpress-indieweb.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: http://wordpress.org/tag/wordpress-indieweb\n"
-"POT-Creation-Date: 2015-01-27 14:41:39+00:00\n"
+"POT-Creation-Date: 2015-01-27 15:16:48+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -16,7 +16,7 @@ msgstr ""
 msgid "Install Required Plugins"
 msgstr ""
 
-#: class-tgm-plugin-activation.php:197
+#: class-tgm-plugin-activation.php:197 getting_started.php:45
 msgid "Install Plugins"
 msgstr ""
 
@@ -255,6 +255,170 @@ msgstr ""
 
 #: class-tgm-plugin-activation.php:2090
 msgid "Installing Plugin %1$s (%2$d/%3$d)"
+msgstr ""
+
+#: getting_started.php:1
+msgid "IndieWebify your WordPress-Blog"
+msgstr ""
+
+#: getting_started.php:3
+msgid "Getting Started"
+msgstr ""
+
+#: getting_started.php:5
+msgid "The Indieweb Plugin can help you get set up to be a more active member of the indieweb. Required plugins make receiving indieweb comments and mentions work, recommended plugins further improve the experience."
+msgstr ""
+
+#: getting_started.php:7
+msgid "Once you have these activated, you can setup <a href=\"https://www.brid.gy\" target=\"_blank\">Bridgy</a> to connect your blog to responses from sites such as Facebook and Twitter too, allowing for a seamless experience."
+msgstr ""
+
+#: getting_started.php:9
+msgid "Plugins"
+msgstr ""
+
+#: getting_started.php:11
+msgid "For more information on these plugins, visit the <a href=\"http://indiewebcamp.com/wordpress\" target=\"_blank\">WordPress page</a> on the Indiewebcamp wiki or click the individual plugin links below."
+msgstr ""
+
+#: getting_started.php:15
+msgid "Send and receive responses with your site"
+msgstr ""
+
+#: getting_started.php:16
+msgid "Send and receive comments, likes, reposts, and other kinds of post responses using your own site!"
+msgstr ""
+
+#: getting_started.php:18
+msgid "<strong>Webmention</strong> <em>(Required)</em> - allows you to send and receive by adding webmention support to WordPress. Mentions show up as comments on your site."
+msgstr ""
+
+#: getting_started.php:19
+msgid "<strong>Semantic Linkbacks</strong> <em>(Required)</em> - makes indieweb comments and mentions look better on your site."
+msgstr ""
+
+#: getting_started.php:20
+msgid "<strong>Webmention for (Threaded) Comments</strong> - Adds support for threaded comments for webmentions."
+msgstr ""
+
+#: getting_started.php:21
+msgid "<strong>Webactions</strong> - Adds webaction markups to WordPress elements."
+msgstr ""
+
+#: getting_started.php:22
+msgid "<strong>Post Kinds</strong> - Allows you to reply/like/RSVP etc to another site from your own, by adding support for kinds of posts to WordPress as a custom taxonomy."
+msgstr ""
+
+#: getting_started.php:27
+msgid "Syndicate your content to other sites"
+msgstr ""
+
+#: getting_started.php:28
+msgid "Choose one of these different ways to display links for POSSE/syndicated versions of a post. They cannot both be used. Linking to the syndicated version of a post allows for bridgy to be able to discover the post as well as for end users to comment on those sites as a way of replying."
+msgstr ""
+
+#: getting_started.php:30
+msgid "<strong>Syndication Links</strong> - Adds fields to a post to allow manual entry of syndication links."
+msgstr ""
+
+#: getting_started.php:31
+msgid "<strong>WordPress Syndication</strong> - automatically adds link to a post from a supported syndication plugin. Fully supports Social, partial support for SNAP, and support for Bridgy Publish."
+msgstr ""
+
+#: getting_started.php:36
+msgid "Other"
+msgstr ""
+
+#: getting_started.php:38
+msgid "<strong>Indieweb Press-This</strong> - Adds Indieweb markup to the WordPressPress-This bookmarkets to allow you to respond on your site with one-click."
+msgstr ""
+
+#: getting_started.php:39
+msgid "<strong>Hum URL Shortener</strong> - A personal URL shortener."
+msgstr ""
+
+#: getting_started.php:40
+msgid "<strong>Indieauth</strong> - The plugin lets you login to the WordPress backend via IndieAuth. It uses the URL from the profile page to identify the blog user."
+msgstr ""
+
+#: getting_started.php:47
+msgid "Themes"
+msgstr ""
+
+#: getting_started.php:49
+msgid "Some WordPress themes are compatible with microformats. The Indieweb uses microformats2, the latest version, to mark up sites so that they can be interpreted by other sites when retrieved. Most parsers will fall back onto the older format if available."
+msgstr ""
+
+#: getting_started.php:51
+msgid "Formatting your site so other sites can consume the information allows for the communications Indieweb sites support. For example, a class of u-like-of added to a link to a site you liked to indicates that relationship."
+msgstr ""
+
+#: getting_started.php:53
+msgid "There is only one theme in the WordPress repository that is fully microformats2 compliant. That is Sempress."
+msgstr ""
+
+#: getting_started.php:55
+msgid "What is the Indieweb?"
+msgstr ""
+
+#: getting_started.php:57
+msgid "<strong>Own your data.</strong> Create and publish content on your own site, and only optionally syndicate to third-party silos."
+msgstr ""
+
+#: getting_started.php:58
+msgid "This is the basis of the <strong>Indie Web</strong>. For more, see <a href=\"http://indiewebcamp.com/principles\" target=\"_blank\">principles</a> and <a href=\"http://indiewebcamp.com/why\" target=\"_blank\">why</a>."
+msgstr ""
+
+#: getting_started.php:60
+msgid "For even more information, please visit the <a href=\"http://indiewebcamp.com/\" target=\"_blank\"><em>IndieWebCamp</em> wiki</a>."
+msgstr ""
+
+#: indieweb.php:65
+msgid "IndieWeb"
+msgstr ""
+
+#: indieweb.php:95
+msgid "WebMention"
+msgstr ""
+
+#: indieweb.php:102
+msgid "Semantic Linkbacks"
+msgstr ""
+
+#: indieweb.php:109
+msgid "Hum (URL shortener)"
+msgstr ""
+
+#: indieweb.php:116
+msgid "WebActions"
+msgstr ""
+
+#: indieweb.php:125
+msgid "IndieWeb Press-This"
+msgstr ""
+
+#: indieweb.php:134
+msgid "WebMention support for (threaded) comments"
+msgstr ""
+
+#: indieweb.php:143
+msgid "Post Kinds"
+msgstr ""
+
+#: indieweb.php:152
+msgid "Syndication Links"
+msgstr ""
+
+#: indieweb.php:161
+msgid "WordPress Syndication"
+msgstr ""
+
+#: indieweb.php:170
+msgid "Indieauth"
+msgstr ""
+
+#: indieweb.php:193
+msgid "For descriptions of the plugins and more information, visit <a href=\"plugins.php?page=indieweb\">Getting Started</a>"
 msgstr ""
 
 #: indieweb.php:195


### PR DESCRIPTION
I'm not 100% happy with how much markup remains in the translatable strings, but it's better than before.