### PR TITLE
Add hooks and make overlooked string translatable

### DIFF
--- a/indieweb.php
+++ b/indieweb.php
@@ -244,7 +244,7 @@ class IndieWebPlugin {
 	 * @return array $links The modified plugin links array
 	 */
 	public static function plugin_link( $links ) {
-		$settings_link = '<a href="' . admin_url( "plugins.php?page=indieweb") . '">Getting Started</a>';
+		$settings_link = '<a href="' . admin_url( 'plugins.php?page=indieweb' ) . '">' . __( 'Getting Started', 'indieweb' ) . '</a>';
 		array_unshift( $links, $settings_link);
 		return $links;
 	}

--- a/indieweb.php
+++ b/indieweb.php
@@ -46,6 +46,9 @@ class IndieWebPlugin {
 		$plugin = plugin_basename( __FILE__ );
 		add_filter( "plugin_action_links_$plugin", array( 'IndieWebPlugin', 'plugin_link' ) );
 
+		// we're up and running
+		do_action( 'indieweb_loaded' );
+
 	}
 
 	/**
@@ -226,7 +229,11 @@ class IndieWebPlugin {
 
 		); // end config array
 
-		tgmpa( $plugins, $config );
+		// call TGM with filtered arrays
+		tgmpa(
+			apply_filters( 'indieweb_tgm_plugins', $plugins ),
+			apply_filters( 'indieweb_tgm_config', $config )
+		);
 
 	}
 

--- a/languages/wordpress-indieweb.pot
+++ b/languages/wordpress-indieweb.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  \n"
 "Report-Msgid-Bugs-To: http://wordpress.org/tag/wordpress-indieweb\n"
-"POT-Creation-Date: 2015-01-27 15:16:48+00:00\n"
+"POT-Creation-Date: 2015-01-28 10:34:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -16,11 +16,11 @@ msgstr ""
 msgid "Install Required Plugins"
 msgstr ""
 
-#: class-tgm-plugin-activation.php:197 getting_started.php:45
+#: class-tgm-plugin-activation.php:197 getting_started.php:47
 msgid "Install Plugins"
 msgstr ""
 
-#: class-tgm-plugin-activation.php:198 indieweb.php:197
+#: class-tgm-plugin-activation.php:198 indieweb.php:212
 msgid "Installing Plugin: %s"
 msgstr ""
 
@@ -40,25 +40,25 @@ msgid_plural "This theme recommends the following plugins: %1$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:202 indieweb.php:201
+#: class-tgm-plugin-activation.php:202 indieweb.php:216
 msgid "Sorry, but you do not have the correct permissions to install the %s plugin. Contact the administrator of this site for help on getting the plugin installed."
 msgid_plural "Sorry, but you do not have the correct permissions to install the %s plugins. Contact the administrator of this site for help on getting the plugins installed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:203 indieweb.php:202
+#: class-tgm-plugin-activation.php:203 indieweb.php:217
 msgid "The following required plugin is currently inactive: %1$s."
 msgid_plural "The following required plugins are currently inactive: %1$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:204 indieweb.php:203
+#: class-tgm-plugin-activation.php:204 indieweb.php:218
 msgid "The following recommended plugin is currently inactive: %1$s."
 msgid_plural "The following recommended plugins are currently inactive: %1$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:205 indieweb.php:204
+#: class-tgm-plugin-activation.php:205 indieweb.php:219
 msgid "Sorry, but you do not have the correct permissions to activate the %s plugin. Contact the administrator of this site for help on getting the plugin activated."
 msgid_plural "Sorry, but you do not have the correct permissions to activate the %s plugins. Contact the administrator of this site for help on getting the plugins activated."
 msgstr[0] ""
@@ -70,19 +70,19 @@ msgid_plural "The following plugins need to be updated to their latest version t
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:207 indieweb.php:206
+#: class-tgm-plugin-activation.php:207 indieweb.php:221
 msgid "Sorry, but you do not have the correct permissions to update the %s plugin. Contact the administrator of this site for help on getting the plugin updated."
 msgid_plural "Sorry, but you do not have the correct permissions to update the %s plugins. Contact the administrator of this site for help on getting the plugins updated."
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:208 indieweb.php:207
+#: class-tgm-plugin-activation.php:208 indieweb.php:222
 msgid "Begin installing plugin"
 msgid_plural "Begin installing plugins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: class-tgm-plugin-activation.php:209 indieweb.php:208
+#: class-tgm-plugin-activation.php:209 indieweb.php:223
 msgid "Begin activating plugin"
 msgid_plural "Begin activating plugins"
 msgstr[0] ""
@@ -97,7 +97,7 @@ msgid "Return to the dashboard"
 msgstr ""
 
 #: class-tgm-plugin-activation.php:212 class-tgm-plugin-activation.php:1965
-#: indieweb.php:210
+#: indieweb.php:225
 msgid "Plugin activated successfully."
 msgstr ""
 
@@ -257,204 +257,204 @@ msgstr ""
 msgid "Installing Plugin %1$s (%2$d/%3$d)"
 msgstr ""
 
-#: getting_started.php:1
+#: getting_started.php:3
 msgid "IndieWebify your WordPress-Blog"
 msgstr ""
 
-#: getting_started.php:3
+#: getting_started.php:5 indieweb.php:247
 msgid "Getting Started"
 msgstr ""
 
-#: getting_started.php:5
+#: getting_started.php:7
 msgid "The Indieweb Plugin can help you get set up to be a more active member of the indieweb. Required plugins make receiving indieweb comments and mentions work, recommended plugins further improve the experience."
 msgstr ""
 
-#: getting_started.php:7
+#: getting_started.php:9
 msgid "Once you have these activated, you can setup <a href=\"https://www.brid.gy\" target=\"_blank\">Bridgy</a> to connect your blog to responses from sites such as Facebook and Twitter too, allowing for a seamless experience."
 msgstr ""
 
-#: getting_started.php:9
+#: getting_started.php:11
 msgid "Plugins"
 msgstr ""
 
-#: getting_started.php:11
+#: getting_started.php:13
 msgid "For more information on these plugins, visit the <a href=\"http://indiewebcamp.com/wordpress\" target=\"_blank\">WordPress page</a> on the Indiewebcamp wiki or click the individual plugin links below."
 msgstr ""
 
-#: getting_started.php:15
+#: getting_started.php:17
 msgid "Send and receive responses with your site"
 msgstr ""
 
-#: getting_started.php:16
+#: getting_started.php:18
 msgid "Send and receive comments, likes, reposts, and other kinds of post responses using your own site!"
 msgstr ""
 
-#: getting_started.php:18
+#: getting_started.php:20
 msgid "<strong>Webmention</strong> <em>(Required)</em> - allows you to send and receive by adding webmention support to WordPress. Mentions show up as comments on your site."
 msgstr ""
 
-#: getting_started.php:19
+#: getting_started.php:21
 msgid "<strong>Semantic Linkbacks</strong> <em>(Required)</em> - makes indieweb comments and mentions look better on your site."
 msgstr ""
 
-#: getting_started.php:20
+#: getting_started.php:22
 msgid "<strong>Webmention for (Threaded) Comments</strong> - Adds support for threaded comments for webmentions."
 msgstr ""
 
-#: getting_started.php:21
+#: getting_started.php:23
 msgid "<strong>Webactions</strong> - Adds webaction markups to WordPress elements."
 msgstr ""
 
-#: getting_started.php:22
+#: getting_started.php:24
 msgid "<strong>Post Kinds</strong> - Allows you to reply/like/RSVP etc to another site from your own, by adding support for kinds of posts to WordPress as a custom taxonomy."
 msgstr ""
 
-#: getting_started.php:27
+#: getting_started.php:29
 msgid "Syndicate your content to other sites"
 msgstr ""
 
-#: getting_started.php:28
+#: getting_started.php:30
 msgid "Choose one of these different ways to display links for POSSE/syndicated versions of a post. They cannot both be used. Linking to the syndicated version of a post allows for bridgy to be able to discover the post as well as for end users to comment on those sites as a way of replying."
 msgstr ""
 
-#: getting_started.php:30
+#: getting_started.php:32
 msgid "<strong>Syndication Links</strong> - Adds fields to a post to allow manual entry of syndication links."
 msgstr ""
 
-#: getting_started.php:31
+#: getting_started.php:33
 msgid "<strong>WordPress Syndication</strong> - automatically adds link to a post from a supported syndication plugin. Fully supports Social, partial support for SNAP, and support for Bridgy Publish."
 msgstr ""
 
-#: getting_started.php:36
+#: getting_started.php:38
 msgid "Other"
 msgstr ""
 
-#: getting_started.php:38
+#: getting_started.php:40
 msgid "<strong>Indieweb Press-This</strong> - Adds Indieweb markup to the WordPressPress-This bookmarkets to allow you to respond on your site with one-click."
 msgstr ""
 
-#: getting_started.php:39
+#: getting_started.php:41
 msgid "<strong>Hum URL Shortener</strong> - A personal URL shortener."
 msgstr ""
 
-#: getting_started.php:40
+#: getting_started.php:42
 msgid "<strong>Indieauth</strong> - The plugin lets you login to the WordPress backend via IndieAuth. It uses the URL from the profile page to identify the blog user."
 msgstr ""
 
-#: getting_started.php:47
+#: getting_started.php:49
 msgid "Themes"
 msgstr ""
 
-#: getting_started.php:49
+#: getting_started.php:51
 msgid "Some WordPress themes are compatible with microformats. The Indieweb uses microformats2, the latest version, to mark up sites so that they can be interpreted by other sites when retrieved. Most parsers will fall back onto the older format if available."
 msgstr ""
 
-#: getting_started.php:51
+#: getting_started.php:53
 msgid "Formatting your site so other sites can consume the information allows for the communications Indieweb sites support. For example, a class of u-like-of added to a link to a site you liked to indicates that relationship."
 msgstr ""
 
-#: getting_started.php:53
+#: getting_started.php:55
 msgid "There is only one theme in the WordPress repository that is fully microformats2 compliant. That is Sempress."
 msgstr ""
 
-#: getting_started.php:55
+#: getting_started.php:57
 msgid "What is the Indieweb?"
 msgstr ""
 
-#: getting_started.php:57
+#: getting_started.php:59
 msgid "<strong>Own your data.</strong> Create and publish content on your own site, and only optionally syndicate to third-party silos."
 msgstr ""
 
-#: getting_started.php:58
+#: getting_started.php:60
 msgid "This is the basis of the <strong>Indie Web</strong>. For more, see <a href=\"http://indiewebcamp.com/principles\" target=\"_blank\">principles</a> and <a href=\"http://indiewebcamp.com/why\" target=\"_blank\">why</a>."
 msgstr ""
 
-#: getting_started.php:60
+#: getting_started.php:62
 msgid "For even more information, please visit the <a href=\"http://indiewebcamp.com/\" target=\"_blank\"><em>IndieWebCamp</em> wiki</a>."
 msgstr ""
 
-#: indieweb.php:65
+#: indieweb.php:78 indieweb.php:79
 msgid "IndieWeb"
 msgstr ""
 
-#: indieweb.php:95
+#: indieweb.php:110
 msgid "WebMention"
 msgstr ""
 
-#: indieweb.php:102
+#: indieweb.php:117
 msgid "Semantic Linkbacks"
 msgstr ""
 
-#: indieweb.php:109
+#: indieweb.php:124
 msgid "Hum (URL shortener)"
 msgstr ""
 
-#: indieweb.php:116
+#: indieweb.php:131
 msgid "WebActions"
 msgstr ""
 
-#: indieweb.php:125
+#: indieweb.php:140
 msgid "IndieWeb Press-This"
 msgstr ""
 
-#: indieweb.php:134
+#: indieweb.php:149
 msgid "WebMention support for (threaded) comments"
 msgstr ""
 
-#: indieweb.php:143
+#: indieweb.php:158
 msgid "Post Kinds"
 msgstr ""
 
-#: indieweb.php:152
+#: indieweb.php:167
 msgid "Syndication Links"
 msgstr ""
 
-#: indieweb.php:161
+#: indieweb.php:176
 msgid "WordPress Syndication"
 msgstr ""
 
-#: indieweb.php:170
+#: indieweb.php:185
 msgid "Indieauth"
 msgstr ""
 
-#: indieweb.php:193
+#: indieweb.php:208
 msgid "For descriptions of the plugins and more information, visit <a href=\"plugins.php?page=indieweb\">Getting Started</a>"
 msgstr ""
 
-#: indieweb.php:195
+#: indieweb.php:210
 msgid "Install Indieweb Plugins"
 msgstr ""
 
-#: indieweb.php:196
+#: indieweb.php:211
 msgid "IndieWeb Plugin Installer"
 msgstr ""
 
-#: indieweb.php:198
+#: indieweb.php:213
 msgid "Something went wrong with the plugin install."
 msgstr ""
 
-#: indieweb.php:199
+#: indieweb.php:214
 msgid "The IndieWeb plugin requires the following plugin: %1$s."
 msgid_plural "The IndieWeb plugin requires the following plugins: %1$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: indieweb.php:200
+#: indieweb.php:215
 msgid "The IndieWeb plugin recommends the following plugin: %1$s."
 msgid_plural "The IndieWeb plugin recommends the following plugins: %1$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: indieweb.php:205
+#: indieweb.php:220
 msgid "The following plugin needs to be updated to its latest version to ensure maximum compatibility with this plugin: %1$s."
 msgid_plural "The following plugins need to be updated to their latest version to ensure maximum compatibility with this theme: %1$s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: indieweb.php:209
+#: indieweb.php:224
 msgid "Return to Indieweb Plugins Installer"
 msgstr ""
 
-#: indieweb.php:211
+#: indieweb.php:226
 msgid "All plugins installed and activated successfully. %s"
 msgstr ""


### PR DESCRIPTION
A couple of enhancements... the hooks allow other plugins to register that wordpress-indieweb is present and active and the filters allow them to add to (or override) the list of installable plugins. Also, makes an overlooked string translatable.