### PR TITLE
adding rel-me support

### DIFF
--- a/indieweb.php
+++ b/indieweb.php
@@ -14,7 +14,105 @@ Domain Path: /languages
 
 // initialize plugin
 add_action( 'plugins_loaded', array( 'IndieWebPlugin', 'init' ) );
+// add widget
+add_action( 'widgets_init', array( 'IndieWebPlugin', 'init_widgets' ) );
 
+
+/**
+ * adds widget to display rel-me links for indieauth with per-user profile support
+ *
+ *
+ */
+class IndieWebPlugin_Widget extends WP_Widget {
+
+	/**
+	 * widget constructor
+	 */
+	function __construct() {
+		parent::__construct(
+			'IndieWebPlugin_Widget',
+			__('Rel-me URLs', 'indieweb'),
+			array(
+				'description' => __( 'Adds automatic rel-me URLs based on author profile information.', 'indieweb' ),
+			)
+		);
+	}
+
+	/**
+	 * widget worker
+	 *
+	 * @param mixed $args widget parameters
+	 * @param mixed $instance saved widget data
+	 *
+	 * @output echoes the list of rel-me links for the author
+	 */
+	public function widget( $args, $instance ) {
+
+		$default_author = ( ! empty( $instance['default_author'] ) ) ? intval( $instance['default_author'] ) : 1;
+		$use_post_author = ( ! empty( $instance['use_post_author'] ) ) ? intval( $instance['use_post_author'] ) : 1;
+
+		if ( is_singular() && 1 == $use_post_author ) {
+			global $post;
+			$author_id = $post->post_author;
+		}
+		else {
+			$author_id = $default_author;
+		}
+
+		echo IndieWebPlugin::rel_me_list ( $author_id );
+	}
+
+	/**
+	 * widget data updater
+	 *
+	 * @param mixed $new_instance new widget data
+	 * @param mixed $old_instance current widget data
+	 *
+	 * @return mixed widget data
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = array();
+		$instance['default_author'] = ( ! empty( $new_instance['default_author'] ) ) ? intval( $new_instance['default_author'] ) : 1;
+
+		$instance['use_post_author'] = ( ! empty( $new_instance['use_post_author'] ) ) ? intval( $new_instance['use_post_author'] ) : 1;
+
+		return $instance;
+	}
+
+	/**
+	 * widget form
+	 *
+	 * @param mixed $instance
+	 *
+	 * @output displays the widget form
+	 *
+	 */
+	public function form( $instance ) {
+		$default_author = ( isset ( $instance['default_author'] ) ) ? $instance['default_author'] : 1;
+		$use_post_author = ( isset ( $instance['use_post_author'] ) ) ? $instance['use_post_author'] : true;
+
+		$users = get_users( array(
+			'orderby' => 'ID',
+			'fields' => array( 'ID', 'display_name' )
+		));
+
+		?>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'default_author' ); ?>"><?php _e( 'Default author:', 'indieweb' ); ?></label>
+			<select name="<?php echo $this->get_field_id( 'default_author' ); ?>" id="<?php echo $this->get_field_id( 'default_author' ); ?>">
+				<?php foreach ( $users as $user ): ?>
+				<option value="<?php echo $user->ID; ?>" <?php selected( $default_author , $user->ID ); ?>><?php echo $user->display_name; ?></option>
+				<?php endforeach; ?>
+			</select>
+		</p>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'use_post_author' ); ?>"><?php _e( 'Use post author for rel-me links source on post-like pages instead of default author:', 'indieweb' ); ?></label>
+			<input id="<?php echo $this->get_field_id( 'use_post_author' ); ?>" name="<?php echo $this->get_field_name( 'use_post_author' ); ?>" type="checkbox" value="1" <?php checked( $instance['use_post_author'], $use_post_author ); ?> />
+		</p>
+		<?php
+	}
+
+}
 
 
 /**
@@ -50,8 +148,13 @@ class IndieWebPlugin {
 
 		// additional user meta fields
 		add_filter('user_contactmethods', array( 'IndieWebPlugin', 'add_user_meta_fields' ) );
+	}
 
-		//add_action( 'wp_footer', array( 'IndieWebPlugin', 'rel_me_list' ) );
+	/**
+	 * register WordPress widgets
+	 */
+	public static function init_widgets() {
+		register_widget( 'IndieWebPlugin_Widget' );
 	}
 
 	/**
@@ -303,8 +406,10 @@ class IndieWebPlugin {
 	 * prints a formatted <ul> list of rel=me to supported silos
 	 *
 	 */
-	public static function rel_me_list ( ) {
-		$author_id = get_the_author_id();
+	public static function rel_me_list ( $author_id = null ) {
+
+		if ( empty( $author_id ) )
+			$author_id = get_the_author_id();
 
 		if ( empty( $author_id ) || $author_id == 0 )
 			return false;

--- a/indieweb.php
+++ b/indieweb.php
@@ -373,7 +373,7 @@ class IndieWebPlugin {
 				'display' => __( 'Twitter username', 'indieweb' ),
 			),
 			'lastfm' => array (
-				'baseurl' => 'last.fm/user/%s',
+				'baseurl' => 'https://last.fm/user/%s',
 				'display' => __( 'Last.fm username', 'indieweb' ),
 			),
 			'flickr' => array (


### PR DESCRIPTION
I've added additional profile fields for silos that are supported by indieauth at the moment, and a widget that displays a list of these fields either for a default author ID or per post author.