### PR TITLE
Fix php 5.3/5.5 problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
     on_failure: change
 
 php:
-  - 5.3
   - 5.6
   - 7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
+language: php
+
+notifications:
+  email:
     on_success: never
     on_failure: change
 
 php:
+  - 5.3
   - 5.6
   - 7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
-language: php
-
-notifications:
-  email:
     on_success: never
     on_failure: change
 
 php:
+  - 5.3
   - 5.6
   - 7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
     on_failure: change
 
 php:
-  - 5.3
   - 5.6
   - 7
 

--- a/includes/class-hcard-user.php
+++ b/includes/class-hcard-user.php
@@ -492,7 +492,7 @@ class HCard_User {
 			$return .= '<span class="p-country-name country-name">' . $user->get( 'country-name' ) . '</span>';
 		}
 		$return .= '</li>';
-		if ( $user->has_prop( 'tel' ) && ! empty( $user->get( 'tel' ) ) ) {
+		if ( $user->has_prop( 'tel' ) && $user->get( 'tel' ) ) {
 			$return .= '<li><a class="p-tel tel" href="tel:' . $user->get( 'tel' ) . '">' . $user->get( 'tel' ) . '</a></li>';
 		}
 		$return .= '</ul>';

--- a/indieweb.php
+++ b/indieweb.php
@@ -5,7 +5,7 @@
  * Description: Interested in connecting your WordPress site to the IndieWeb?
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
- * Version: 3.3.0
+ * Version: 3.3.1
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: indieweb

--- a/languages/wordpress-indieweb.pot
+++ b/languages/wordpress-indieweb.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieWeb 3.3.0\n"
+"Project-Id-Version: IndieWeb 3.3.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieweb\n"
-"POT-Creation-Date: 2017-10-01 16:37:17+00:00\n"
+"POT-Creation-Date: 2017-10-04 19:28:37+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "A widget that allows you to display h-cards for a specific author"
 msgstr ""
 
-#: includes/class-hcard-author-widget.php:110
+#: includes/class-hcard-author-widget.php:99
 msgid "Avatar Size:"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.3  
 **Tested up to:** 4.8.2  
-**Stable tag:** 3.3.0  
+**Stable tag:** 3.3.1  
 
 IndieWeb for WordPress!
 
@@ -79,11 +79,13 @@ One could certainly download, install, and activate some or all of these plugins
 
 Project maintained on github at [indieweb/wordpress-indieweb](https://github.com/indieweb/wordpress-indieweb).
 
+### 3.3.1 ###
+* fix PHP compatibility problem
+
 ### 3.3.0 ###
 * Add Basic H-Card widget
 * Minor fixes
 * Basic CONTRIBUTING.md
-
 
 ### 3.2.2 ###
 * Change extra rel-me field to array to ensure proper handlin

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: indieweb, webmention, POSSE, indieauth
 Requires at least: 4.7
 Requires PHP: 5.3
 Tested up to: 4.8.2
-Stable tag: 3.3.0
+Stable tag: 3.3.1
 
 IndieWeb for WordPress!
 
@@ -79,11 +79,13 @@ One could certainly download, install, and activate some or all of these plugins
 
 Project maintained on github at [indieweb/wordpress-indieweb](https://github.com/indieweb/wordpress-indieweb).
 
+= 3.3.1 =
+* fix PHP compatibility problem
+
 = 3.3.0 =
 * Add Basic H-Card widget
 * Minor fixes
 * Basic CONTRIBUTING.md
-
 
 = 3.2.2 =
 * Change extra rel-me field to array to ensure proper handlin


### PR DESCRIPTION
```
-----------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------
 495 | ERROR | Only variables can be passed to empty() prior to PHP 5.5.
-----------------------------------------------------------------------------------------
```

see also https://wordpress.org/support/topic/update-to-3-3-0-gives-me-white-screen-breaks-site/