### PR TITLE
Issue 101 - Add email to h-card widget (optionally)

### DIFF
--- a/includes/class-hcard-author-widget.php
+++ b/includes/class-hcard-author-widget.php
@@ -75,6 +75,9 @@ class HCard_Author_Widget extends WP_Widget {
 			$instance[ $k ] = strip_tags( $v );
 		}
 
+		// Apply changes to checkboxes which are unchecked when absent from the POST
+		$instance [ 'reveal_email' ] = isset( $new_instance [ 'reveal_email' ] ) ? 'on' : '';
+
 		return $instance;
 	}
 
@@ -91,6 +94,7 @@ class HCard_Author_Widget extends WP_Widget {
 		// Set up some default widget settings
 		$defaults = array(
 			'avatar_size' => '125',
+			'reveal_email' => ''
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -98,6 +102,10 @@ class HCard_Author_Widget extends WP_Widget {
 	   <p>
 		<label for="<?php echo $this->get_field_id( 'avatar_size' ); ?>"><?php _e( 'Avatar Size:', 'indieweb' ); ?></label>
 		<input type="text" name="<?php echo $this->get_field_name( 'avatar_size' ); ?>" id="<?php echo $this->get_field_id( 'avatar_size' ); ?>" value="<?php echo $instance['avatar_size']; ?>" />
+	   </p>
+	   <p>
+		<input class="checkbox" type="checkbox" <?php checked( $instance[ 'reveal_email' ], 'on' ); ?> id="<?= $this->get_field_id( 'reveal_email' ); ?>" name="<?= $this->get_field_name( 'reveal_email' ); ?>" />
+		<label for="<?= $this->get_field_id( 'reveal_email' ); ?>"><?php _e( 'Reveal email address in public:', 'indieweb' ); ?></label>
 	   </p>
 
 

--- a/includes/class-hcard-author-widget.php
+++ b/includes/class-hcard-author-widget.php
@@ -76,7 +76,7 @@ class HCard_Author_Widget extends WP_Widget {
 		}
 
 		// Apply changes to checkboxes which are unchecked when absent from the POST
-		$instance [ 'reveal_email' ] = isset( $new_instance [ 'reveal_email' ] ) ? 'on' : '';
+		$instance[ 'reveal_email' ] = isset( $new_instance[ 'reveal_email' ] ) ? 'on' : '';
 
 		return $instance;
 	}

--- a/includes/class-hcard-author-widget.php
+++ b/includes/class-hcard-author-widget.php
@@ -76,7 +76,7 @@ class HCard_Author_Widget extends WP_Widget {
 		}
 
 		// Apply changes to checkboxes which are unchecked when absent from the POST
-		$instance[ 'reveal_email' ] = isset( $new_instance[ 'reveal_email' ] ) ? 'on' : '';
+		$instance['reveal_email'] = isset( $new_instance['reveal_email'] ) ? 'on' : '';
 
 		return $instance;
 	}
@@ -94,7 +94,7 @@ class HCard_Author_Widget extends WP_Widget {
 		// Set up some default widget settings
 		$defaults = array(
 			'avatar_size' => '125',
-			'reveal_email' => ''
+			'reveal_email' => '',
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -104,7 +104,7 @@ class HCard_Author_Widget extends WP_Widget {
 		<input type="text" name="<?php echo $this->get_field_name( 'avatar_size' ); ?>" id="<?php echo $this->get_field_id( 'avatar_size' ); ?>" value="<?php echo $instance['avatar_size']; ?>" />
 	   </p>
 	   <p>
-		<input class="checkbox" type="checkbox" <?php checked( $instance[ 'reveal_email' ], 'on' ); ?> id="<?= $this->get_field_id( 'reveal_email' ); ?>" name="<?= $this->get_field_name( 'reveal_email' ); ?>" />
+		<input class="checkbox" type="checkbox" <?php checked( $instance['reveal_email'], 'on' ); ?> id="<?php echo $this->get_field_id( 'reveal_email' ); ?>" name="<?php echo $this->get_field_name( 'reveal_email' ); ?>" />
 		<label for="<?= $this->get_field_id( 'reveal_email' ); ?>"><?php _e( 'Reveal email address in public:', 'indieweb' ); ?></label>
 	   </p>
 

--- a/includes/class-hcard-author-widget.php
+++ b/includes/class-hcard-author-widget.php
@@ -105,7 +105,7 @@ class HCard_Author_Widget extends WP_Widget {
 	   </p>
 	   <p>
 		<input class="checkbox" type="checkbox" <?php checked( $instance['reveal_email'], 'on' ); ?> id="<?php echo $this->get_field_id( 'reveal_email' ); ?>" name="<?php echo $this->get_field_name( 'reveal_email' ); ?>" />
-		<label for="<?= $this->get_field_id( 'reveal_email' ); ?>"><?php _e( 'Reveal email address in public:', 'indieweb' ); ?></label>
+		<label for="<?php echo $this->get_field_id( 'reveal_email' ); ?>"><?php _e( 'Reveal email address in public:', 'indieweb' ); ?></label>
 	   </p>
 
 

--- a/includes/class-hcard-user.php
+++ b/includes/class-hcard-user.php
@@ -501,7 +501,7 @@ class HCard_User {
 		);
 		$url    = $user->has_prop( 'user_url' ) ? $user->get( 'user_url' ) : $url = get_author_posts_url( $user->ID );
 		$name   = $user->get( 'display_name' );
-		$email	= $user->get( 'user_email' );
+		$email  = $user->get( 'user_email' );
 
 		$return  = '<div class="hcard-display h-card vcard p-author">';
 		$return .= '<div class="hcard-header">';
@@ -512,7 +512,7 @@ class HCard_User {
 			$return .= $avatar . '</a>';
 			$return .= '<p class="hcard-name p-name n">' . $name . '</p>';
 		}
-		if ( 'on' === $r[ 'reveal_email' ] ) {
+		if ( 'on' === $r['reveal_email'] ) {
 			$return .= '<p class="u-email"><a rel="me" href="mailto:' . $email . '">' . $email . '</a></p>';
 		}
 		$return .= '</div>';

--- a/includes/class-hcard-user.php
+++ b/includes/class-hcard-user.php
@@ -501,6 +501,7 @@ class HCard_User {
 		);
 		$url    = $user->has_prop( 'user_url' ) ? $user->get( 'user_url' ) : $url = get_author_posts_url( $user->ID );
 		$name   = $user->get( 'display_name' );
+		$email	= $user->get( 'user_email' );
 
 		$return  = '<div class="hcard-display h-card vcard p-author">';
 		$return .= '<div class="hcard-header">';
@@ -510,6 +511,9 @@ class HCard_User {
 		} else {
 			$return .= $avatar . '</a>';
 			$return .= '<p class="hcard-name p-name n">' . $name . '</h2>';
+		}
+		if ( 'on' === $r[ 'reveal_email' ] ) {
+			$return .= '<p class="u-email"><a rel="me" href="mailto:' . $email . '">' . $email . '</a></p>';
 		}
 		$return .= '</div>';
 		$return .= '<div class="hcard-body">';


### PR DESCRIPTION
I added a setting in the widget to reveal email address publicly. This allows me to pass step 2 at indiewebify.me which otherwise would require leaving WP dashboard and diving into code to add my email address here.

I did a fresh WP install and cloned the plugin from my branch here to ensure the setting is off by default.

Closes #101 