### PR TITLE
remove uf2 plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ sass/.sass-cache
 npm-debug.log
 package-lock.json
 composer.lock
+.DS_Store

--- a/indieweb.php
+++ b/indieweb.php
@@ -169,9 +169,6 @@ class IndieWeb_Plugin {
 				'slug' => 'indieauth',
 			),
 			array(
-				'slug' => 'wp-uf2',
-			),
-			array(
 				'slug' => 'simple-location',
 			),
 			array(

--- a/indieweb.php
+++ b/indieweb.php
@@ -5,7 +5,7 @@
  * Description: Interested in connecting your WordPress site to the IndieWeb?
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
- * Version: 3.3.10
+ * Version: 3.3.11
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: indieweb

--- a/languages/wordpress-indieweb.pot
+++ b/languages/wordpress-indieweb.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieWeb 3.3.10\n"
+"Project-Id-Version: IndieWeb 3.3.11\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieweb\n"
-"POT-Creation-Date: 2018-08-06 04:18:29+00:00\n"
+"POT-Creation-Date: 2018-09-13 18:42:16+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -458,7 +458,7 @@ msgid ""
 "functionality."
 msgstr ""
 
-#: indieweb.php:186
+#: indieweb.php:183
 msgid ""
 "Users can optionally add additional information to their profile. As this "
 "is part of your user profile you have control of this information and can "

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.3  
 **Tested up to:** 4.9.8  
-**Stable tag:** 3.3.10  
+**Stable tag:** 3.3.11  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 
@@ -82,6 +82,9 @@ One could certainly download, install, and activate some or all of these plugins
 ## Changelog ##
 
 Project maintained on github at [indieweb/wordpress-indieweb](https://github.com/indieweb/wordpress-indieweb).
+
+### 3.3.11 ###
+* Removed uf2 plugin from recommended plugins
 
 ### 3.3.10 ###
 * Fix email property not being used and hook it to setting

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: indieweb, webmention, POSSE, indieauth
 Requires at least: 4.7
 Requires PHP: 5.3
 Tested up to: 4.9.8
-Stable tag: 3.3.10
+Stable tag: 3.3.11
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
@@ -83,7 +83,10 @@ One could certainly download, install, and activate some or all of these plugins
 
 Project maintained on github at [indieweb/wordpress-indieweb](https://github.com/indieweb/wordpress-indieweb).
 
-= 3.3.10 = 
+= 3.3.11 =
+* Removed uf2 plugin from recommended plugins
+
+= 3.3.10 =
 * Fix email property not being used and hook it to setting
 * Fix micro.blog icon
 * Fix PHP notice
@@ -107,7 +110,7 @@ Project maintained on github at [indieweb/wordpress-indieweb](https://github.com
 * Remove last.fm due no indieweb support
 * Add option for the icons to be black and white only
 
-= 3.3.6 = 
+= 3.3.6 =
 * Refresh icons
 
 = 3.3.5 =


### PR DESCRIPTION
The uf2 plugin has too many issues at the moment, so I would vote for removing it, until it is fixed.

The mf1 implementations of the twenty* themes, seems to be better than the mf2 output of this plugin.