### PR TITLE
Adds support for h-card.php template to be loaded from active theme

### DIFF
--- a/includes/class-hcard-user.php
+++ b/includes/class-hcard-user.php
@@ -498,6 +498,11 @@ class HCard_User {
 		return apply_filters( 'hcard_display_defaults', $defaults );
 	}
 
+	public static function get_template_file( $file_name ) {
+		$theme_template_file = locate_template( $file_name );
+		return $theme_template_file ? $theme_template_file : dirname( __FILE__ ) . '/../templates/' . $file;
+	}
+
 	public static function hcard( $user, $args = array() ) {
 		if ( ! $user ) {
 			return false;
@@ -525,7 +530,7 @@ class HCard_User {
 		$name  = $user->get( 'display_name' );
 		$email = $user->get( 'user_email' );
 		ob_start();
-		include dirname( __FILE__ ) . '/../templates/h-card.php';
+		include self::get_template_file( 'h-card.php' );
 		$return = ob_get_contents();
 		ob_end_clean();
 		return $return;

--- a/includes/class-hcard-user.php
+++ b/includes/class-hcard-user.php
@@ -498,9 +498,17 @@ class HCard_User {
 		return apply_filters( 'hcard_display_defaults', $defaults );
 	}
 
+	/**
+	 * Looks up, and returns if exists, the full path to a given file in the
+	 * /templates subdirectory of the active theme (child, parent).
+	 * Defaults to the /templates subdirectory in this plugin.
+	 *
+	 * @param string $file_name   File name, example: h-card.php
+	 * @return string             Full path to file
+	 */
 	public static function get_template_file( $file_name ) {
-		$theme_template_file = locate_template( $file_name );
-		return $theme_template_file ? $theme_template_file : dirname( __FILE__ ) . '/../templates/' . $file;
+		$theme_template_file = locate_template( 'templates/' . $file_name );
+		return $theme_template_file ? $theme_template_file : dirname( __FILE__ ) . '/../templates/' . $file_name;
 	}
 
 	public static function hcard( $user, $args = array() ) {


### PR DESCRIPTION
- Added method `HCard_User::get_template_file()` which utilises [`locate_template()`](https://developer.wordpress.org/reference/functions/locate_template/) to scan the active theme (child or parent) for an identical file name in a theme subfolder named `templates`. (That subfolder is a standard in WordPress core and starter themes, so it seems fair to require it as part of the file path, although more flexibility could be achieved with an additional filter if necessary in the future.)
- The `h-card.php` file can now be copied to the active theme and will be loaded from there, with graceful degradation to the default file from the `templates` folder in this plugin.

Template file will be looked up in these locations:
```
wp-content
   ┣━themes
   ┃ ┣━example-child-theme
   ┃ ┃ ┗━templates
1. ┃ ┃   ┗━h-card.php
   ┃ ┗━example-theme
   ┃   ┗━templates
2. ┃     ┗━h-card.php
   ┗━plugins
     ┗━indieweb
       ┗━templates
3.       ┗━h-card.php
```