### PR TITLE
check if we have a WP_User object before trying to fetch the ID. Sinc…

### DIFF
--- a/includes/class-relme-widget.php
+++ b/includes/class-relme-widget.php
@@ -40,7 +40,7 @@ class RelMe_Widget extends WP_Widget {
 		}
 		if ( is_author() ) {
 			global $authordata;
-			$author_id = $authordata->ID;
+			$author_id = ( $authordata instanceof WP_User ) ? $authordata->ID : 1;
 			if ( 0 === (int) $single_author ) {
 				$include_rel = true;
 			}


### PR DESCRIPTION
…e we have at least ONE user, default to user ID 1.

Addresses part of #110 