### PR TITLE
Update Composer/GitHub Actions to Latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -5,26 +5,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           coverage: none
           tools: composer, cs2pr
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Setup cache
-        uses: pat-s/always-upload-cache@v1.1.4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          # Use the hash of composer.json as the key for your cache if you do not commit composer.lock. 
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          #key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+      - name: Install Composer dependencies for PHP
+        uses: "ramsey/composer-install@v2"
       - name: Detect coding standard violations
         run: composer lint
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,7 @@ jobs:
         php-versions: ['5.6', '7.2', '7.3', '7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -27,7 +27,7 @@ jobs:
           tools: composer, phpunit-polyfills
           extensions: mysql
        - name: Install Composer dependencies for PHP
-         uses: "ramsey/composer-install@v1"
+         uses: "ramsey/composer-install@v2"
        - name: Setup Test Environment
          run: composer setup-local-tests
        - name: Unit Testing

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,7 +15,7 @@ jobs:
        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
     strategy:
       matrix:
-        php-versions: ['5.6', '7.2', '7.3', '7.4']
+        php-versions: ['5.6', '7.2', '7.3', '7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,13 +24,13 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: none
-          tools: composer, phpunit-polyfills
+          tools: composer, , phpunit-polyfills
           extensions: mysql
-       - name: Install Composer dependencies for PHP
-         uses: "ramsey/composer-install@v2"
-       - name: Setup Test Environment
-         run: composer setup-local-tests
-       - name: Unit Testing
-         run: composer phpunit
-           env:
-           PHP_VERSION: ${{ matrix.php-versions }}
+      - name: Install Composer dependencies for PHP
+        uses: "ramsey/composer-install@v2"
+      - name: Setup Test Environment
+        run: composer setup-local-tests
+      - name: Unit Testing
+        run: composer phpunit
+        env:
+          PHP_VERSION: ${{ matrix.php-versions }}

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -8,7 +8,7 @@ jobs:
     name: Push to trunk
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@master
       env:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,13 @@
   "description": "IndieWeb for WordPress!",
   "require": {
     "php": ">=5.6.0",
-    "composer/installers": "~2.1"
+    "composer/installers": "^1.0 | ^2.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "extra": {
     "installer-name": "indieweb"
@@ -30,10 +36,9 @@
 	"phpcompatibility/php-compatibility": "*",
 	"wp-coding-standards/wpcs": "*",
 	"phpcompatibility/phpcompatibility-wp": "*",
-	"php-parallel-lint/php-parallel-lint": "^1.2",
+	"php-parallel-lint/php-parallel-lint": "^1.3",
 	"wp-cli/i18n-command": "^2.2",
 	"sebastian/phpcpd": "^3.0 || ^5.0 || ^6.0",
-	"phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.5",
 	"yoast/phpunit-polyfills": "^1.0"
   },
   "prefer-stable" : true,


### PR DESCRIPTION
Same as PR used in wordpress-indieauth to bring Actions to latest and cover PHP8.0