### PR TITLE
Add IndieBlocks

### DIFF
--- a/indieweb.php
+++ b/indieweb.php
@@ -177,7 +177,7 @@ class IndieWeb_Plugin {
 				'slug' => 'pubsubhubbub',
 			),
 			array(
-				'slug' => 'classic-editor',
+				'slug' => 'indieblocks',
 			),
 		);
 		return $plugin_array;


### PR DESCRIPTION
I like what @janboddez has done with blocks and I would remove the classic-editor and recommend to add it as dependency to the post-kinds plugin, because otherwise it is no requirement.