### PR TITLE
Fix fatal error in REST API on WP 7.0

### DIFF
--- a/includes/hcard/class-user.php
+++ b/includes/hcard/class-user.php
@@ -263,7 +263,8 @@ class User {
 			'me',
 			array(
 				'get_callback' => function ( $user ) {
-					return array_values( self::get_rel_me( $user['id'] ) );
+					$rel_me = self::get_rel_me( $user['id'] );
+					return $rel_me ? array_values( $rel_me ) : array();
 				},
 			)
 		);


### PR DESCRIPTION
## Summary
- Fix `array_values()` fatal error when `get_rel_me()` returns `false` in the `me` REST field callback
- Returns an empty array instead of passing `false` to `array_values()`

Closes #310

## Test plan
- [ ] Request `/wp/v2/users/<id>` for a user with no rel-me links configured
- [ ] Verify no fatal error on WP 7.0-beta5