### PR TITLE
Fix broken styles and scripts on extensions page

### DIFF
--- a/includes/class-indieweb.php
+++ b/includes/class-indieweb.php
@@ -62,6 +62,10 @@ class Indieweb {
 		\add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_style' ) );
 
+		// Plugin installer (extensions page).
+		$plugin_installer = new Plugin_Installer();
+		$plugin_installer->start();
+
 		// Admin menu and settings.
 		\add_action( 'admin_menu', array( $this, 'add_menu_item' ), 9 );
 		\add_action( 'admin_menu', array( General_Settings::class, 'admin_menu' ) );

--- a/includes/class-plugin-installer.php
+++ b/includes/class-plugin-installer.php
@@ -5,7 +5,7 @@
  * @author   Darren Cooney
  * @link     https://github.com/dcooney/wordpress-plugin-installer
  * @link     https://connekthq.com
- * @version  1.0
+ * @version  1.0.2
  * @package  Indieweb
  */
 
@@ -20,9 +20,9 @@ class Plugin_Installer {
 	 * Start the installer.
 	 */
 	public function start() {
-		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) ); // Enqueue scripts and Localize.
-		\add_action( 'wp_ajax_cnkt_plugin_installer', array( $this, 'cnkt_plugin_installer' ) ); // Install plugin.
-		\add_action( 'wp_ajax_cnkt_plugin_activation', array( $this, 'cnkt_plugin_activation' ) ); // Activate plugin.
+		\add_action( 'cnkt_installer_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		\add_action( 'wp_ajax_cnkt_plugin_installer', array( $this, 'cnkt_plugin_installer' ) );
+		\add_action( 'wp_ajax_cnkt_plugin_activation', array( $this, 'cnkt_plugin_activation' ) );
 	}
 
 	/**
@@ -31,6 +31,8 @@ class Plugin_Installer {
 	 * @param array $plugins Array of plugin data.
 	 */
 	public static function init( $plugins ) {
+		// Add the required plugin scripts.
+		\do_action( 'cnkt_installer_enqueue_scripts' );
 		?>
 
 		<div class="cnkt-plugin-installer">
@@ -63,10 +65,12 @@ class Plugin_Installer {
 				)
 			);
 
-			if ( ! \is_wp_error( $api ) ) { // Confirm error free.
+			if ( ! \is_wp_error( $api ) ) {
 
 				$main_plugin_file = self::get_plugin_file( $plugin['slug'] ); // Get main plugin file.
-				if ( self::check_file_extension( $main_plugin_file ) ) { // Check file extension.
+
+				// Plugin is installed.
+				if ( $main_plugin_file ) {
 					if ( \is_plugin_active( $main_plugin_file ) ) {
 						// Plugin activation, confirmed!
 						$button_classes = 'button disabled';
@@ -297,25 +301,6 @@ class Plugin_Installer {
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * A helper to check file extension.
-	 *
-	 * @param string $filename The filename of the plugin.
-	 * @return bool True if PHP file, false otherwise.
-	 */
-	public static function check_file_extension( $filename ) {
-		if ( ! $filename ) {
-			return false;
-		}
-
-		if ( substr( strrchr( $filename, '.' ), 1 ) === 'php' ) {
-			// Has .php extension.
-			return true;
-		} else {
-			return false;
-		}
 	}
 
 	/**

--- a/includes/class-plugin-installer.php
+++ b/includes/class-plugin-installer.php
@@ -306,6 +306,10 @@ class Plugin_Installer {
 	 * @return bool True if PHP file, false otherwise.
 	 */
 	public static function check_file_extension( $filename ) {
+		if ( ! $filename ) {
+			return false;
+		}
+
 		if ( substr( strrchr( $filename, '.' ), 1 ) === 'php' ) {
 			// Has .php extension.
 			return true;

--- a/includes/class-plugin-installer.php
+++ b/includes/class-plugin-installer.php
@@ -339,8 +339,3 @@ class Plugin_Installer {
 		\wp_enqueue_style( 'plugin-installer', CNKT_INSTALLER_PATH . 'static/css/installer.css', array(), INDIEWEB_VERSION );
 	}
 }
-
-
-// Initialize.
-$indieweb_plugin_installer = new Plugin_Installer();
-$indieweb_plugin_installer->start();

--- a/includes/class-plugin-installer.php
+++ b/includes/class-plugin-installer.php
@@ -318,7 +318,7 @@ class Plugin_Installer {
 	 * Enqueue admin scripts and scripts localization.
 	 */
 	public function enqueue_scripts() {
-		\wp_enqueue_script( 'plugin-installer', CNKT_INSTALLER_PATH . 'static/js/installer.js', array( 'jquery' ), Indieweb::$version, true );
+		\wp_enqueue_script( 'plugin-installer', CNKT_INSTALLER_PATH . 'static/js/installer.js', array( 'jquery' ), INDIEWEB_VERSION, true );
 		\wp_localize_script(
 			'plugin-installer',
 			'cnkt_installer_localize',
@@ -332,7 +332,7 @@ class Plugin_Installer {
 			)
 		);
 
-		\wp_enqueue_style( 'plugin-installer', CNKT_INSTALLER_PATH . 'static/css/installer.css', array(), Indieweb::$version );
+		\wp_enqueue_style( 'plugin-installer', CNKT_INSTALLER_PATH . 'static/css/installer.css', array(), INDIEWEB_VERSION );
 	}
 }
 

--- a/indieweb.php
+++ b/indieweb.php
@@ -5,7 +5,7 @@
  * Description: Interested in connecting your WordPress site to the IndieWeb?
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
- * Version: 5.1.0
+ * Version: 5.1.1
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: indieweb
@@ -15,7 +15,7 @@
 
 namespace Indieweb;
 
-\define( 'INDIEWEB_VERSION', '5.1.0' );
+\define( 'INDIEWEB_VERSION', '5.1.1' );
 
 \defined( 'INDIEWEB_ADD_HCARD_SUPPORT' ) || \define( 'INDIEWEB_ADD_HCARD_SUPPORT', true );
 \defined( 'INDIEWEB_ADD_RELME_SUPPORT' ) || \define( 'INDIEWEB_ADD_RELME_SUPPORT', true );

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 - Requires at least: 4.7
 - Requires PHP: 7.4
 - Tested up to: 7.0
-- Stable tag: 5.1.0
+- Stable tag: 5.1.1
 - License: MIT
 - License URI: http://opensource.org/licenses/MIT
 
@@ -79,6 +79,9 @@ One could certainly download, install, and activate some or all of these plugins
 ## Changelog
 
 Project maintained on github at [indieweb/wordpress-indieweb](https://github.com/indieweb/wordpress-indieweb).
+
+### 5.1.1
+* Fix broken styles and scripts on extensions page caused by referencing non-existent static property
 
 ### 5.1.0
 * Tested with WordPress 7.0

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,9 @@ One could certainly download, install, and activate some or all of these plugins
 Project maintained on github at [indieweb/wordpress-indieweb](https://github.com/indieweb/wordpress-indieweb).
 
 ### 5.1.1
-* Fix broken styles and scripts on extensions page caused by referencing non-existent static property
+* Update Plugin Installer to upstream version 1.0.2
+* Fix broken styles and scripts on extensions page
+* Fix PHP deprecation warning for uninstalled plugins
 
 ### 5.1.0
 * Tested with WordPress 7.0


### PR DESCRIPTION
## Summary

- `Plugin_Installer::enqueue_scripts()` referenced `Indieweb::$version`, a static property that doesn't exist on the `Indieweb` class
- This caused a PHP fatal error, preventing `installer.css` and `installer.js` from loading on the Extensions page
- Replaced with the `INDIEWEB_VERSION` constant, consistent with the rest of the plugin

## Test plan

- [ ] Navigate to IndieWeb → Extensions in wp-admin
- [ ] Verify the page renders with proper card layout styling
- [ ] Verify Install/Activate buttons work (JS loaded correctly)