### PR TITLE
use the indieweb i as menu icon

### DIFF
--- a/includes/class-indieweb.php
+++ b/includes/class-indieweb.php
@@ -129,7 +129,7 @@ class Indieweb {
 			'manage_options',
 			'indieweb',
 			array( $this, 'getting_started' ),
-			INDIEWEB_PLUGIN_URL . 'static/img/indieweb.svg'
+			INDIEWEB_PLUGIN_URL . 'static/img/indieweb-icon.svg'
 		);
 		\add_submenu_page(
 			'indieweb',

--- a/includes/class-indieweb.php
+++ b/includes/class-indieweb.php
@@ -120,6 +120,20 @@ class Indieweb {
 	}
 
 	/**
+	 * Get the menu icon.
+	 *
+	 * The "i" of the IndieWeb logo as a base64 encoded SVG, so that
+	 * WordPress colors it like the other menu icons.
+	 *
+	 * @return string The menu icon as a data URI.
+	 */
+	public function get_menu_icon() {
+		$icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#a7aaad" d="M4 4.1h16v4.5H4zM4 10.2h16v9.8H4z"/></svg>';
+
+		return 'data:image/svg+xml;base64,' . base64_encode( $icon ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding the menu icon.
+	}
+
+	/**
 	 * Add Top Level Menu Item.
 	 */
 	public function add_menu_item() {
@@ -129,7 +143,7 @@ class Indieweb {
 			'manage_options',
 			'indieweb',
 			array( $this, 'getting_started' ),
-			INDIEWEB_PLUGIN_URL . 'static/img/indieweb-icon.svg'
+			$this->get_menu_icon()
 		);
 		\add_submenu_page(
 			'indieweb',

--- a/static/img/indieweb-icon.svg
+++ b/static/img/indieweb-icon.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 117.8 116.8" width="20" height="20"><path fill="#fff" d="M0 0h117.8v33H0zM0 45h117.8v71.8H0z"/></svg>

--- a/static/img/indieweb-icon.svg
+++ b/static/img/indieweb-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 117.8 116.8" width="20" height="20"><path fill="#fff" d="M0 0h117.8v33H0zM0 45h117.8v71.8H0z"/></svg>


### PR DESCRIPTION
<img width="304" height="179" alt="Screenshot 2026-08-31 at 14 53 13" src="https://github.com/user-attachments/assets/827d6de2-8e6b-4225-b53f-80332bc5c844" />


The admin menu used the full IndieWeb logo, squeezed into the 20px icon slot. This replaces it with just the "i" of the logo, as a base64 encoded SVG, so WordPress colors it like the other menu icons (gray by default, white when active).

Based on #300, so that one should be merged first.